### PR TITLE
fixed imports

### DIFF
--- a/bounce/bounce.py
+++ b/bounce/bounce.py
@@ -1,6 +1,6 @@
 import math
 
-from graphics import Canvas
+from bounce.graphics import Canvas
 import random
 import time
 
@@ -11,7 +11,7 @@ import json
 try:
     from . import utils_seeding as seeding
 except:
-    import utils_seeding as seeding
+    import bounce.utils_seeding as seeding
 
 screen_width = 400
 screen_height = 400


### PR DESCRIPTION
When installing bounce as a package, the relative imports in bounce.env were broken. Fixed this by explicitly using the package name when importing graphics and utils_seeding